### PR TITLE
Create a Go web server and basic HTML page.

### DIFF
--- a/go-webserver/go.mod
+++ b/go-webserver/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/go-webserver
+
+go 1.22.2

--- a/go-webserver/main.go
+++ b/go-webserver/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func main() {
+	// Create a file server handler that serves files from the "static" directory.
+	fs := http.FileServer(http.Dir("./static"))
+
+	// Register the file server handler to serve requests for the root path ("/").
+	http.Handle("/", fs)
+
+	// Print a message to the console indicating that the server is starting on port 8080.
+	log.Println("Starting server on :8080")
+
+	// Start the HTTP server on port 8080 and log any errors.
+	err := http.ListenAndServe(":8080", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go-webserver/main_test.go
+++ b/go-webserver/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestServeHTTP(t *testing.T) {
+	// Create a new HTTP request for a GET request to "/".
+	req := httptest.NewRequest("GET", "/", nil)
+
+	// Create a new HTTP response recorder.
+	rr := httptest.NewRecorder()
+
+	// Create a file server handler similar to the one in main.go.
+	fs := http.FileServer(http.Dir("./static"))
+
+	// Call the handler's ServeHTTP method with the response recorder and the request.
+	fs.ServeHTTP(rr, req)
+
+	// Check if the response status code is http.StatusOK.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check if the response body contains the string "Hello from Go Webserver!".
+	expected := "Hello from Go Webserver!"
+	if !strings.Contains(rr.Body.String(), expected) {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
+}

--- a/go-webserver/static/index.html
+++ b/go-webserver/static/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Go Webserver</title>
+</head>
+<body>
+    <h1>Hello from Go Webserver!</h1>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a simple Go web server that serves static files.
- Creates `go-webserver/main.go` with the web server logic.
- Creates `go-webserver/static/index.html` as the page to be served.
- Adds `go-webserver/main_test.go` to test the server functionality.
- Initializes `go.mod` in the `go-webserver` directory.

The server listens on port 8080 and serves content from the `static` directory. The test verifies that the `index.html` page is served correctly.